### PR TITLE
Fix one-off error in `ReviewAnalysisAdapter`

### DIFF
--- a/app/src/main/java/com/amaze/fileutilities/home_page/ui/analyse/ReviewAnalysisAdapter.kt
+++ b/app/src/main/java/com/amaze/fileutilities/home_page/ui/analyse/ReviewAnalysisAdapter.kt
@@ -107,12 +107,14 @@ class ReviewAnalysisAdapter(
         }
     }
 
+    /** Returns the number of items. There might be dummy items, that are also counted here */
     override fun getItemCount(): Int {
         return mediaFileListItems.size
     }
 
+    /** Returns the number of actual items. Dummy items are not counted. */
     override fun getOnlyItemsCount(): Int {
-        return mediaFileListItems.size
+        return mediaFileListItems.size - 1
     }
 
     override fun getItemViewType(position: Int): Int {


### PR DESCRIPTION
Fixes #151 by changing `getOnlyItemsCount` to return the number of actual items.