### PR TITLE
Sort growing apps by change in size

### DIFF
--- a/app/src/main/java/com/amaze/fileutilities/home_page/ui/files/FilesViewModel.kt
+++ b/app/src/main/java/com/amaze/fileutilities/home_page/ui/files/FilesViewModel.kt
@@ -2021,8 +2021,12 @@ class FilesViewModel(val applicationContext: Application) :
                 }
             }
 
-            val result = priorityQueue.reversed()
-            largeSizeDiffAppsLiveData?.postValue(result.toMutableList())
+            val result = mutableListOf<MediaFileInfo>()
+            while (priorityQueue.isNotEmpty()) {
+                result.add(priorityQueue.remove())
+            }
+
+            largeSizeDiffAppsLiveData?.postValue(result.asReversed())
         }
     }
 


### PR DESCRIPTION
This fixes the bug that the growing apps list was not sorted. It is now sorted by the size changes with the biggest size change first.

Related to #141 