### PR TITLE
chore: upgrade to targetSDK 34

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 buildscript {
     ext {
-        jacocoVersion = "0.8.7"
         androidXLifecycleVersion = "2.3.1"
         glideVersion = '4.16.0'
         fragment_version = "1.3.6"
@@ -33,7 +32,6 @@ buildscript {
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
-    id 'com.hiya.jacoco-android'
     id 'kotlin-parcelize'
     id 'kotlin-kapt'
     id("com.github.triplet.play") version "3.8.1"
@@ -48,12 +46,12 @@ android {
         release
     }
 
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.amaze.fileutilities"
         minSdk 21
-        targetSdk 33
+        targetSdk 34
 
         Integer sudoVersionCode = 35
         String versionNameText = "1.94"
@@ -80,7 +78,7 @@ android {
 
             splits {
                 abi {
-                    enable true
+                    enable = true
                     reset()
                     include abiFilterList[0] //select ABIs to build APKs for
                     universalApk false //generate an additional APK that contains all the ABIs
@@ -89,7 +87,7 @@ android {
         } else {
             splits {
                 abi {
-                    enable true
+                    enable = true
                     reset()
                     include 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a' //select ABIs to build APKs for
                     universalApk false //generate an additional APK that contains all the ABIs
@@ -313,15 +311,6 @@ dependencies {
     androidTestImplementation "androidx.room:room-testing:$roomVersion"
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
-}
-
-jacoco {
-    toolVersion = "${jacocoVersion}"
-}
-
-tasks.withType(Test) {
-    jacoco.includeNoLocationClasses = true
-    jacoco.excludes = ['jdk.internal.*']
 }
 
 Properties props = new Properties()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:7.3.1"
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0'
-        classpath 'com.hiya:jacoco-android:0.2'
         classpath "com.project.starter:easylauncher:6.1.0"
         classpath "com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin:10.0.0"
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,7 @@ dependencyResolutionManagement {
         jcenter() // Warning: this repository is going to shut down soon
         maven { url "https://jitpack.io" }
         maven { url "https://jcenter.bintray.com" }
+        maven { url "https://artifactory.appodeal.com/appodeal-public/" }
     }
 }
 rootProject.name = "Amaze File Utilities"


### PR DESCRIPTION
- upgraded SDK to 34
   - upgrading to 35 needs some more work, meanwhile we can let this get released, IMO
- removed jacoco for now temporarily
   - since the https://github.com/arturdm/jacoco-android-gradle-plugin/ plugin is outdated - should figure out another way later